### PR TITLE
Fix ruby 3.0 deprections

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 2.5
 
 Layout/LineLength:
   Max: 120

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ rvm:
   - 2.5
   - 2.6
   - 2.7
+  - 3.0
 before_install:
   - rm Gemfile.lock
   - gem install bundler

--- a/lib/tarpon/entity/offerings.rb
+++ b/lib/tarpon/entity/offerings.rb
@@ -12,12 +12,12 @@ module Tarpon
       def initialize(current_offering_id:, offerings:, **)
         @current_offering_id = current_offering_id
         @offerings = offerings.each_with_object({}) do |offering, map|
-          map[offering[:identifier].to_sym] = Tarpon::Entity::Offering.new(offering)
+          map[offering[:identifier].to_sym] = Tarpon::Entity::Offering.new(**offering)
         end
       end
 
-      def each
-        @offerings.each { |o| yield o }
+      def each(&block)
+        @offerings.each(&block)
       end
 
       def [](identifier)

--- a/lib/tarpon/request/subscriber/offering.rb
+++ b/lib/tarpon/request/subscriber/offering.rb
@@ -14,7 +14,7 @@ module Tarpon
           response = perform(method: :get, path: path.to_s, headers: { 'x-platform': platform.to_s }, key: :public)
           return response unless response.success?
 
-          Tarpon::Entity::Offerings.new(response.raw)
+          Tarpon::Entity::Offerings.new(**response.raw)
         end
 
         private

--- a/lib/tarpon/response.rb
+++ b/lib/tarpon/response.rb
@@ -7,7 +7,7 @@ module Tarpon
     def initialize(status, attributes)
       @status     = status
       @raw        = attributes
-      @subscriber = @raw[:subscriber].nil? ? nil : Entity::Subscriber.new(@raw[:subscriber])
+      @subscriber = @raw[:subscriber] && Entity::Subscriber.new(@raw[:subscriber])
     end
 
     def message

--- a/spec/support/shared_examples/revenue_cat_http_call_shared_example.rb
+++ b/spec/support/shared_examples/revenue_cat_http_call_shared_example.rb
@@ -3,7 +3,7 @@
 def stub_rc_request(method:, api_key:, uri:, headers: {}, body: '')
   default_headers = {
     'Accept' => 'application/json',
-    'Authorization' => "Bearer #{described_class.send(api_key.to_s + '_api_key')}",
+    'Authorization' => "Bearer #{described_class.send("#{api_key}_api_key")}",
     'Content-type' => 'application/json'
   }
   headers.merge!(default_headers)
@@ -25,7 +25,7 @@ RSpec.shared_examples 'an http call to RevenueCat' do |options|
     before { stubbed_request.to_return(status: 404) }
 
     it 'raises Tarpon::NotFoundError' do
-      expect { base_call.send(*client_call) }.to raise_error(Tarpon::NotFoundError)
+      expect { client_call }.to raise_error(Tarpon::NotFoundError)
     end
   end
 
@@ -33,7 +33,7 @@ RSpec.shared_examples 'an http call to RevenueCat' do |options|
     before { stubbed_request.to_return(status: 500) }
 
     it 'raises Tarpon::ServerError' do
-      expect { base_call.send(*client_call) }.to raise_error(Tarpon::ServerError)
+      expect { client_call }.to raise_error(Tarpon::ServerError)
     end
   end
 
@@ -41,7 +41,7 @@ RSpec.shared_examples 'an http call to RevenueCat' do |options|
     before { stubbed_request.to_return(status: 401) }
 
     it 'raises Tarpon::InvalidCredentialsError' do
-      expect { base_call.send(*client_call) }.to raise_error(Tarpon::InvalidCredentialsError)
+      expect { client_call }.to raise_error(Tarpon::InvalidCredentialsError)
     end
   end
 
@@ -49,7 +49,7 @@ RSpec.shared_examples 'an http call to RevenueCat' do |options|
     before { stubbed_request.to_timeout }
 
     it 'raises Tarpon::TimeoutError' do
-      expect { base_call.send(*client_call) }.to raise_error(Tarpon::TimeoutError)
+      expect { client_call }.to raise_error(Tarpon::TimeoutError)
     end
   end
 
@@ -57,7 +57,7 @@ RSpec.shared_examples 'an http call to RevenueCat' do |options|
     before { stubbed_request.to_return(status: 400, body: JSON.generate(message: 'message')) }
 
     it 'maps response to internal response object' do
-      r = base_call.send(*client_call)
+      r = client_call
 
       expect(r).not_to be_success
       expect(r.raw[:message]).to eq('message')
@@ -79,7 +79,7 @@ RSpec.shared_examples 'an http call to RevenueCat' do |options|
     end
 
     it 'maps response to internal response object' do
-      r = base_call.send(*client_call)
+      r = client_call
 
       if options[:response] == :custom && defined?(response_expectation)
         response_expectation.call(r)

--- a/spec/tarpon/client/receipt_spec.rb
+++ b/spec/tarpon/client/receipt_spec.rb
@@ -6,8 +6,6 @@ RSpec.describe Tarpon::Client do
   let(:app_user_id) { 'app-user-id' }
 
   describe '.receipt' do
-    let(:base_call) { described_class.receipt }
-
     describe '.create' do
       it_behaves_like 'an http call to RevenueCat responding with subscriber object', method: :post, api_key: :public do
         let(:platform) { 'ios' }
@@ -19,7 +17,7 @@ RSpec.describe Tarpon::Client do
             fetch_token: 'fetch-token'
           }
         end
-        let(:client_call) { [:create, platform: platform, **body] }
+        let(:client_call) { described_class.receipt.create(platform: platform, **body) }
       end
     end
   end

--- a/spec/tarpon/client/subscriber_spec.rb
+++ b/spec/tarpon/client/subscriber_spec.rb
@@ -6,18 +6,16 @@ RSpec.describe Tarpon::Client do
   let(:app_user_id) { 'app-user-id' }
 
   describe '.subscriber' do
-    let(:base_call) { described_class.subscriber(app_user_id) }
-
     describe '.get_or_create' do
       it_behaves_like 'an http call to RevenueCat responding with subscriber object', method: :get, api_key: :public do
-        let(:client_call) { [:get_or_create] }
+        let(:client_call) { described_class.subscriber(app_user_id).get_or_create }
         let(:uri) { "#{described_class.base_uri}/subscribers/#{app_user_id}" }
       end
     end
 
     describe '.delete' do
       it_behaves_like 'an http call to RevenueCat', method: :delete, api_key: :secret, response: :custom do
-        let(:client_call) { [:delete] }
+        let(:client_call) { described_class.subscriber(app_user_id).delete }
         let(:uri) { "https://api.revenuecat.com/v1/subscribers/#{app_user_id}" }
         let(:response) { JSON.generate(app_user_id: app_user_id) }
         let(:response_expectation) do
@@ -30,14 +28,14 @@ RSpec.describe Tarpon::Client do
     end
 
     describe '.entitlements' do
-      let(:base_call) { described_class.subscriber(app_user_id).entitlements(entitlement_id) }
       let(:entitlement_id) { 'premium' }
+      let(:entitlement) { described_class.subscriber(app_user_id).entitlements(entitlement_id) }
 
       describe '.grant_promotional' do
         it_behaves_like 'an http call to RevenueCat responding with subscriber object',
                         method: :post, api_key: :secret do
           let(:body) { { duration: 'weekly', start_time_ms: 123 } }
-          let(:client_call) { [:grant_promotional, body] }
+          let(:client_call) { entitlement.grant_promotional(**body) }
           let(:uri) do
             "#{described_class.base_uri}/subscribers/#{app_user_id}/entitlements/#{entitlement_id}/promotional"
           end
@@ -47,7 +45,7 @@ RSpec.describe Tarpon::Client do
       describe '.revoke_promotional' do
         it_behaves_like 'an http call to RevenueCat responding with subscriber object',
                         method: :post, api_key: :secret do
-          let(:client_call) { [:revoke_promotional] }
+          let(:client_call) { entitlement.revoke_promotional }
           let(:uri) do
             "#{described_class.base_uri}/subscribers/#{app_user_id}/entitlements/#{entitlement_id}/revoke_promotionals"
           end
@@ -57,7 +55,7 @@ RSpec.describe Tarpon::Client do
 
     describe '.delete' do
       it_behaves_like 'an http call to RevenueCat', method: :delete, api_key: :secret, response: :custom do
-        let(:client_call) { [:delete] }
+        let(:client_call) { described_class.subscriber(app_user_id).delete }
         let(:uri) { "https://api.revenuecat.com/v1/subscribers/#{app_user_id}" }
         let(:response) { JSON.generate(app_user_id: app_user_id) }
         let(:response_expectation) do
@@ -70,12 +68,11 @@ RSpec.describe Tarpon::Client do
     end
 
     describe '.offerings' do
-      let(:base_call) { described_class.subscriber(app_user_id).offerings }
       let(:platform) { 'ios' }
 
       it_behaves_like 'an http call to RevenueCat',
                       method: :get, api_key: :public, response: :custom do
-        let(:client_call) { [:list, platform] }
+        let(:client_call) { described_class.subscriber(app_user_id).offerings.list platform }
         let(:uri) do
           "#{described_class.base_uri}/subscribers/#{app_user_id}/offerings"
         end
@@ -93,14 +90,14 @@ RSpec.describe Tarpon::Client do
     end
 
     describe '.subscriptions' do
-      let(:base_call) { described_class.subscriber(app_user_id).subscriptions(product_id) }
       let(:product_id) { 'monthly' }
+      let(:product) { described_class.subscriber(app_user_id).subscriptions(product_id) }
 
       describe '.defer' do
         it_behaves_like 'an http call to RevenueCat responding with subscriber object',
                         method: :post, api_key: :secret do
           let(:body) { { expiry_time_ms: 123_45 } }
-          let(:client_call) { [:defer, body] }
+          let(:client_call) { product.defer(**body) }
           let(:uri) { "#{described_class.base_uri}/subscribers/#{app_user_id}/subscriptions/#{product_id}/defer" }
         end
       end

--- a/tarpon.gemspec
+++ b/tarpon.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
+  spec.required_ruby_version = '>= 2.5'
 
   spec.add_dependency 'http', '~> 4.3'
 


### PR DESCRIPTION
To be able to support Ruby 3.0 we need to fix some breaking changes with keyword arguments. See https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/
