### PR TITLE
Add Entitlement's purchase_date accessor

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    tarpon (0.2.1)
+    tarpon (0.3.1)
       http (~> 4.3)
 
 GEM
@@ -24,20 +24,20 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     factory_bot (5.1.1)
       activesupport (>= 4.2.0)
-    ffi (1.12.2)
+    ffi (1.15.3)
     ffi-compiler (1.0.1)
       ffi (>= 1.0.0)
       rake
     hashdiff (1.0.0)
-    http (4.3.0)
+    http (4.4.1)
       addressable (~> 2.3)
       http-cookie (~> 1.0)
       http-form_data (~> 2.2)
       http-parser (~> 1.2.0)
-    http-cookie (1.0.3)
+    http-cookie (1.0.4)
       domain_name (~> 0.5)
-    http-form_data (2.2.0)
-    http-parser (1.2.1)
+    http-form_data (2.3.0)
+    http-parser (1.2.3)
       ffi-compiler (>= 1.0, < 2.0)
     i18n (1.8.3)
       concurrent-ruby (~> 1.0)
@@ -78,7 +78,7 @@ GEM
       thread_safe (~> 0.1)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.6)
+    unf_ext (0.0.7.7)
     unicode-display_width (1.6.1)
     webmock (3.8.2)
       addressable (>= 2.3.6)

--- a/lib/tarpon/entity/entitlement.rb
+++ b/lib/tarpon/entity/entitlement.rb
@@ -17,6 +17,10 @@ module Tarpon
       def expires_date
         Time.iso8601(@raw[:expires_date])
       end
+
+      def purchase_date
+        Time.iso8601(@raw[:purchase_date])
+      end
     end
   end
 end

--- a/lib/tarpon/version.rb
+++ b/lib/tarpon/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Tarpon
-  VERSION = '0.3.0'
+  VERSION = '0.3.1'
 end

--- a/spec/tarpon/entity/entitlement_spec.rb
+++ b/spec/tarpon/entity/entitlement_spec.rb
@@ -47,4 +47,10 @@ RSpec.describe Tarpon::Entity::Entitlement do
       expect(subject.expires_date).to eq Time.iso8601(attributes[:expires_date])
     end
   end
+
+  describe '#purchase_date' do
+    it 'parses the iso8601 purchase_date' do
+      expect(subject.purchase_date).to eq Time.iso8601(attributes[:purchase_date])
+    end
+  end
 end


### PR DESCRIPTION
The `Entitlement` class conveniently exposed a `expires_date` method that parses the raw date value, but was missing the same thing for `purchase_date`. This PR simply adds that `purchase_date` method.