### PR TITLE
Add too many request error

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,6 +12,9 @@ Metrics/BlockLength:
   Exclude:
     - 'spec/**/*'
 
+Metrics/MethodLength:
+  Max: 20
+
 Style/FrozenStringLiteralComment:
   Exclude:
     - 'bin/*'

--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ By default, Tarpon will raise custom errors in the following occasions:
 
 - `Tarpon::TimeoutError` will be raised when RevenueCat server takes too long to respond, based on `Tarpon::Client.timeout`.
 
+- `Tarpon::TooManyRequests` will be raise when RevenueCat server responds with 429 status code.
+
 For success and client error status codes, Tarpon will parse it to the response object.
 
 #### The Response object

--- a/lib/tarpon/errors.rb
+++ b/lib/tarpon/errors.rb
@@ -6,4 +6,5 @@ module Tarpon
   class InvalidCredentialsError < Error; end
   class ServerError < Error; end
   class NotFoundError < Error; end
+  class TooManyRequests < Error; end
 end

--- a/lib/tarpon/request/base.rb
+++ b/lib/tarpon/request/base.rb
@@ -56,6 +56,8 @@ module Tarpon
           raise Tarpon::ServerError, 'RevenueCat failed to fulfill the request'
         when 404
           raise Tarpon::NotFoundError
+        when 429
+          raise Tarpon::TooManyRequests
         else
           create_response(http_response)
         end


### PR DESCRIPTION
Revenue Cat can only handle one request at a time for single user so we got an issue when many clients (iOS/Android/Rutilus) tried to call `get_or_create` subscriber and got 429 issue.
I wanted to catch this error and let client (Rutilus) aware of it and handle it accordingly, e.g: retry

<img width="1107" alt="revenuecat_429" src="https://user-images.githubusercontent.com/87298636/135992454-a6be9a3f-3dab-4bc5-94f1-c3e7989404bb.png">
