### PR TITLE
Support instantiating different API clients, and advanced HTTP configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,12 +229,12 @@ end
 
 You can access the HTTP requests as they are performed for advanced configuration, allowing you to configure things such as logging, instrumentation, more granular timeouts, or using an HTTP proxy.
 
-Under the hood, Tarpon uses the [HTTP.rb](https://github.com/httprb/http) library, which provides an easy to extend API to configure HTTP requests. You can access this by providing a custom `http` Proc when configuring a `Tarpon::Client`.
+Under the hood, Tarpon uses the [HTTP.rb](https://github.com/httprb/http) library, which provides an easy to extend API to configure HTTP requests. You can access this by providing a custom `http_middleware` Proc when configuring a `Tarpon::Client` that receives and returns an `HTTP::Client`.
 
 ```ruby
 Tarpon::Client.configure do |c|
-  c.http = ->(http) do
-    http
+  c.http_middleware = ->(http_client) do
+    http_client
       .use(instrumentation: { instrumenter: ActiveSupport::Notifications.instrumenter })
       .via('https://custom.proxy.com', 8080)
   end

--- a/README.md
+++ b/README.md
@@ -37,6 +37,30 @@ end
 
 Get your credentials from the [RevenueCat dashboard](https://app.revenuecat.com/apps/). Read more about [authentication on the RevenueCat docs](https://docs.revenuecat.com/docs/authentication).
 
+#### Configuring multiple clients
+
+If you need to support different configurations (e.g. to target different RevenueCat projects), you can instantiate different Tarpon clients. For example:
+
+```ruby
+PROJECT_1_RC_CLIENT = Tarpon::Client.new do |c|
+  c.public_api_key = 'project-1-public-key'
+  c.secret_api_key = 'project-1-secret-key'
+end
+
+PROJECT_2_RC_CLIENT = Tarpon::Client.new do |c|
+  c.public_api_key = 'project-2-public-key'
+  c.secret_api_key = 'project-2-secret-key'
+end
+```
+
+And then you can use them instead of calling methods on `Tarpon::Client`. For example:
+
+```ruby
+PROEJCT_1_RC_CLIENT
+  .subscriber('app_user_id')
+  .get_or_create
+```
+
 ### Performing requests
 
 #### Get or create a subscriber

--- a/README.md
+++ b/README.md
@@ -225,6 +225,22 @@ response.subscriber.entitlements.each do |entitlement|
 end
 ```
 
+## Advanced HTTP configuration
+
+You can access the HTTP requests as they are performed for advanced configuration, allowing you to configure things such as logging, instrumentation, more granular timeouts, or using an HTTP proxy.
+
+Under the hood, Tarpon uses the [HTTP.rb](https://github.com/httprb/http) library, which provides an easy to extend API to configure HTTP requests. You can access this by providing a custom `http` Proc when configuring a `Tarpon::Client`.
+
+```ruby
+Tarpon::Client.configure do |c|
+  c.http = ->(http) do
+    http
+      .use(instrumentation: { instrumenter: ActiveSupport::Notifications.instrumenter })
+      .via('https://custom.proxy.com', 8080)
+  end
+end
+```
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/fishbrain/tarpon.

--- a/README.md
+++ b/README.md
@@ -61,6 +61,12 @@ PROEJCT_1_RC_CLIENT
   .get_or_create
 ```
 
+You can also pass configuration values as a Hash to the `Tarpon::Client` constructor, if desired:
+
+```ruby
+Tarpon::Client.new(public_api_key: 'public-key', private_api_key: 'private-key')
+```
+
 ### Performing requests
 
 #### Get or create a subscriber

--- a/lib/tarpon/client.rb
+++ b/lib/tarpon/client.rb
@@ -1,19 +1,32 @@
 # frozen_string_literal: true
 
+require 'forwardable'
 require 'tarpon/configuration'
 
 module Tarpon
   class Client
-    extend Configuration
+    include Configuration
+
+    def self.default
+      @default ||= new
+    end
+
+    def initialize(&block)
+      yield self if block
+    end
 
     class << self
-      def subscriber(app_user_id)
-        Request::Subscriber.new(app_user_id: app_user_id)
-      end
+      extend Forwardable
+      def_delegators :default, *Configuration.public_instance_methods(true)
+      def_delegators :default, :subscriber, :receipt
+    end
 
-      def receipt
-        Request::Receipt.new
-      end
+    def subscriber(app_user_id)
+      Request::Subscriber.new(app_user_id: app_user_id, client: self)
+    end
+
+    def receipt
+      Request::Receipt.new(client: self)
     end
   end
 end

--- a/lib/tarpon/client.rb
+++ b/lib/tarpon/client.rb
@@ -11,7 +11,8 @@ module Tarpon
       @default ||= new
     end
 
-    def initialize(&block)
+    def initialize(**config, &block)
+      config.each { |key, val| send("#{key}=", val) }
       yield self if block
     end
 

--- a/lib/tarpon/client.rb
+++ b/lib/tarpon/client.rb
@@ -12,7 +12,7 @@ module Tarpon
     end
 
     def initialize(**config, &block)
-      config.each { |key, val| send("#{key}=", val) }
+      config.each { |key, val| public_send("#{key}=", val) }
       yield self if block
     end
 

--- a/lib/tarpon/configuration.rb
+++ b/lib/tarpon/configuration.rb
@@ -3,7 +3,7 @@
 module Tarpon
   module Configuration
     attr_accessor :public_api_key, :secret_api_key
-    attr_writer :base_uri, :timeout
+    attr_writer :base_uri, :timeout, :http
 
     def configure
       yield self
@@ -15,6 +15,10 @@ module Tarpon
 
     def timeout
       @timeout || 5
+    end
+
+    def http
+      @http || ->(http) { http }
     end
   end
 end

--- a/lib/tarpon/configuration.rb
+++ b/lib/tarpon/configuration.rb
@@ -3,7 +3,7 @@
 module Tarpon
   module Configuration
     attr_accessor :public_api_key, :secret_api_key
-    attr_writer :base_uri, :timeout, :http
+    attr_writer :base_uri, :timeout, :http_middleware
 
     def configure
       yield self
@@ -17,8 +17,8 @@ module Tarpon
       @timeout || 5
     end
 
-    def http
-      @http || ->(http) { http }
+    def http_middleware
+      @http_middleware ||= ->(http_client) { http_client }
     end
   end
 end

--- a/lib/tarpon/request/base.rb
+++ b/lib/tarpon/request/base.rb
@@ -20,7 +20,7 @@ module Tarpon
       def perform(method:, path:, key:, headers: {}, body: nil)
         HTTP
           .timeout(@client.timeout)
-          .then { |http_client| @client.http.call(http_client) }
+          .then { |http_client| @client.http_middleware.call(http_client) }
           .auth("Bearer #{api_key(key)}")
           .headers(headers.merge(DEFAULT_HEADERS))
           .send(method, "#{@client.base_uri}#{path}", json: body&.compact)

--- a/lib/tarpon/request/base.rb
+++ b/lib/tarpon/request/base.rb
@@ -20,6 +20,7 @@ module Tarpon
       def perform(method:, path:, key:, headers: {}, body: nil)
         HTTP
           .timeout(@client.timeout)
+          .then { |http_client| @client.http.call(http_client) }
           .auth("Bearer #{api_key(key)}")
           .headers(headers.merge(DEFAULT_HEADERS))
           .send(method, "#{@client.base_uri}#{path}", json: body&.compact)

--- a/lib/tarpon/request/subscriber.rb
+++ b/lib/tarpon/request/subscriber.rb
@@ -17,15 +17,19 @@ module Tarpon
       end
 
       def entitlements(entitlement_identifier)
-        self.class::Entitlement.new(subscriber_path: path, entitlement_identifier: entitlement_identifier)
+        self.class::Entitlement.new(
+          subscriber_path: path,
+          entitlement_identifier: entitlement_identifier,
+          client: @client
+        )
       end
 
       def offerings
-        self.class::Offering.new(subscriber_path: path)
+        self.class::Offering.new(subscriber_path: path, client: @client)
       end
 
       def subscriptions(product_id)
-        self.class::Subscription.new(subscriber_path: path, product_id: product_id)
+        self.class::Subscription.new(subscriber_path: path, product_id: product_id, client: @client)
       end
 
       private

--- a/lib/tarpon/request/subscriber.rb
+++ b/lib/tarpon/request/subscriber.rb
@@ -3,8 +3,8 @@
 module Tarpon
   module Request
     class Subscriber < Base
-      def initialize(app_user_id:)
-        super()
+      def initialize(app_user_id:, **opts)
+        super(**opts)
         @app_user_id = app_user_id
       end
 

--- a/lib/tarpon/request/subscriber/entitlement.rb
+++ b/lib/tarpon/request/subscriber/entitlement.rb
@@ -4,8 +4,8 @@ module Tarpon
   module Request
     class Subscriber
       class Entitlement < Base
-        def initialize(subscriber_path:, entitlement_identifier:)
-          super()
+        def initialize(subscriber_path:, entitlement_identifier:, **opts)
+          super(**opts)
           @subscriber_path = subscriber_path
           @entitlement_identifier = entitlement_identifier
         end

--- a/lib/tarpon/request/subscriber/offering.rb
+++ b/lib/tarpon/request/subscriber/offering.rb
@@ -6,8 +6,8 @@ module Tarpon
   module Request
     class Subscriber
       class Offering < Base
-        def initialize(subscriber_path:)
-          super()
+        def initialize(subscriber_path:, **opts)
+          super(**opts)
           @subscriber_path = subscriber_path
         end
 

--- a/lib/tarpon/request/subscriber/subscription.rb
+++ b/lib/tarpon/request/subscriber/subscription.rb
@@ -4,8 +4,8 @@ module Tarpon
   module Request
     class Subscriber
       class Subscription < Base
-        def initialize(subscriber_path:, product_id:)
-          super()
+        def initialize(subscriber_path:, product_id:, **opts)
+          super(**opts)
           @subscriber_path = subscriber_path
           @product_id = product_id
         end

--- a/spec/support/shared_examples/revenue_cat_http_call_shared_example.rb
+++ b/spec/support/shared_examples/revenue_cat_http_call_shared_example.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-def stub_rc_request(method:, api_key:, uri:, headers: {}, body: '')
+def stub_rc_request(method:, api_key:, uri:, client:, headers: {}, body: '') # rubocop:disable Metrics/ParameterLists
   default_headers = {
     'Accept' => 'application/json',
-    'Authorization' => "Bearer #{described_class.send("#{api_key}_api_key")}",
+    'Authorization' => "Bearer #{client.send("#{api_key}_api_key")}",
     'Content-type' => 'application/json'
   }
   headers.merge!(default_headers)
@@ -17,9 +17,12 @@ RSpec.shared_examples 'an http call to RevenueCat' do |options|
       api_key: options[:api_key],
       headers: defined?(headers) ? headers : {},
       body: defined?(body) ? JSON.generate(body) : nil,
-      uri: uri
+      uri: uri,
+      client: client
     )
   end
+
+  let(:client) { described_class }
 
   context 'when server responds with 404' do
     before { stubbed_request.to_return(status: 404) }

--- a/spec/support/shared_examples/revenue_cat_http_call_shared_example.rb
+++ b/spec/support/shared_examples/revenue_cat_http_call_shared_example.rb
@@ -24,6 +24,10 @@ RSpec.shared_examples 'an http call to RevenueCat' do |options|
 
   let(:client) { described_class }
 
+  it 'has a configured API key' do
+    expect(client.send("#{options[:api_key]}_api_key")).to_not be_nil
+  end
+
   context 'when server responds with 404' do
     before { stubbed_request.to_return(status: 404) }
 

--- a/spec/tarpon/client/receipt_spec.rb
+++ b/spec/tarpon/client/receipt_spec.rb
@@ -10,14 +10,14 @@ RSpec.describe Tarpon::Client do
       it_behaves_like 'an http call to RevenueCat responding with subscriber object', method: :post, api_key: :public do
         let(:platform) { 'ios' }
         let(:headers) { { 'X-Platform' => platform } }
-        let(:uri) { "#{described_class.base_uri}/receipts" }
+        let(:uri) { "#{client.base_uri}/receipts" }
         let(:body) do
           {
             app_user_id: app_user_id,
             fetch_token: 'fetch-token'
           }
         end
-        let(:client_call) { described_class.receipt.create(platform: platform, **body) }
+        let(:client_call) { client.receipt.create(platform: platform, **body) }
       end
     end
   end

--- a/spec/tarpon/client_spec.rb
+++ b/spec/tarpon/client_spec.rb
@@ -19,16 +19,40 @@ RSpec.describe Tarpon::Client do
   end
 
   it 'receives configuration values when instantiating' do
+    http_proc = ->(http) { http }
+
     subject = described_class.new(
       public_api_key: 'public-key',
       secret_api_key: 'secret-key',
       timeout: 3,
-      base_uri: 'https://example.com'
+      base_uri: 'https://example.com',
+      http: http_proc
     )
 
     expect(subject.public_api_key).to eq('public-key')
     expect(subject.secret_api_key).to eq('secret-key')
     expect(subject.timeout).to eq(3)
     expect(subject.base_uri).to eq('https://example.com')
+    expect(subject.http).to eq(http_proc)
+  end
+
+  describe 'advanced HTTP request configuration' do
+    let(:http_calls) { [] }
+    let(:client) do
+      Tarpon::Client.new do |c|
+        c.http = lambda do |http_call|
+          http_calls << http_call
+          http_call
+        end
+      end
+    end
+
+    before { stub_request(:any, /api\.revenuecat\.com/) }
+
+    it 'evaluates the HTTP config block on every request' do
+      client.subscriber(app_user_id).get_or_create
+
+      expect(http_calls).to include(an_instance_of(HTTP::Client))
+    end
   end
 end

--- a/spec/tarpon/client_spec.rb
+++ b/spec/tarpon/client_spec.rb
@@ -12,6 +12,8 @@ RSpec.describe Tarpon::Client do
 
       let(:client) do
         Tarpon::Client.new do |c|
+          c.public_api_key = 'test-public-key'
+          c.secret_api_key = 'test-secret-key'
           c.base_uri = 'https://example.com/client_1'
         end
       end

--- a/spec/tarpon/client_spec.rb
+++ b/spec/tarpon/client_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Tarpon::Client do
+  let(:app_user_id) { 'app-user-id' }
+
+  describe 'configuring different clients' do
+    it_behaves_like 'an http call to RevenueCat responding with subscriber object', method: :get, api_key: :public do
+      let(:client_call) { client.subscriber(app_user_id).get_or_create }
+      let(:uri) { "https://example.com/client_1/subscribers/#{app_user_id}" }
+
+      let(:client) do
+        Tarpon::Client.new do |c|
+          c.base_uri = 'https://example.com/client_1'
+        end
+      end
+    end
+  end
+end

--- a/spec/tarpon/client_spec.rb
+++ b/spec/tarpon/client_spec.rb
@@ -17,4 +17,18 @@ RSpec.describe Tarpon::Client do
       end
     end
   end
+
+  it 'receives configuration values when instantiating' do
+    subject = described_class.new(
+      public_api_key: 'public-key',
+      secret_api_key: 'secret-key',
+      timeout: 3,
+      base_uri: 'https://example.com'
+    )
+
+    expect(subject.public_api_key).to eq('public-key')
+    expect(subject.secret_api_key).to eq('secret-key')
+    expect(subject.timeout).to eq(3)
+    expect(subject.base_uri).to eq('https://example.com')
+  end
 end

--- a/spec/tarpon/client_spec.rb
+++ b/spec/tarpon/client_spec.rb
@@ -21,30 +21,30 @@ RSpec.describe Tarpon::Client do
   end
 
   it 'receives configuration values when instantiating' do
-    http_proc = ->(http) { http }
+    http_middleware = ->(http_client) { http_client }
 
     subject = described_class.new(
       public_api_key: 'public-key',
       secret_api_key: 'secret-key',
       timeout: 3,
       base_uri: 'https://example.com',
-      http: http_proc
+      http_middleware: http_middleware
     )
 
     expect(subject.public_api_key).to eq('public-key')
     expect(subject.secret_api_key).to eq('secret-key')
     expect(subject.timeout).to eq(3)
     expect(subject.base_uri).to eq('https://example.com')
-    expect(subject.http).to eq(http_proc)
+    expect(subject.http_middleware).to eq(http_middleware)
   end
 
   describe 'advanced HTTP request configuration' do
     let(:http_calls) { [] }
     let(:client) do
       Tarpon::Client.new do |c|
-        c.http = lambda do |http_call|
-          http_calls << http_call
-          http_call
+        c.http_middleware = lambda do |http_client|
+          http_calls << http_client
+          http_client
         end
       end
     end


### PR DESCRIPTION
This PR allows you to use Tarpon to target multiple different RevenueCat Projects from within the same codebase.

Our use case is probably uncommon, but we have a backend that supports multiple different mobile apps, each with its own RevenueCat configuration, as a different Project in RC. This means different API keys, and at that point Tarpon is not able to work, since the configuration happens in a singleton object (the `Tarpon::Client` class).

This changes the library so that it now instantiates `Tarpon::Client` and calls methods on the instances, rather than calling singleton methods on the class:

```ruby
config.project_1.revenue_cat = Tarpon::Client.new do |c|
  c.public_api_key = ENV['PROJECT_1_REVENUE_CAT_PUBLIC_KEY']
  c.secret_api_key = ENV['PROJECT_1_REVENUE_CAT_SECRET_KEY']
end

config.project_2.revenue_cat = Tarpon::Client.new do |c|
  # ...
end
```

In order to preserve backwards compatibility—and to support the common use case of just needing to target a single RevenueCat project, this also introduces a `Tarpon::Client.default` instance to which all methods are delegated.

This allows users to continue using the same API, but provides the flexibility to target different projects if needed.

This also provides a new API to configure clients, by passing properties to `Client.new`. This makes it easy for use in e.g. Rails, where you might want to use something like `config_for` to load different configurations from a YAML file.

Finally, this extends the configuration to allow a Proc to be passed to configure the `HTTP.rb` requests made under the hood, to enable any and all features of that library, such as instrumentation, proxy usage, or granular timeouts:

```ruby
Tarpon::Client.new do |c|
  c.http = ->(http) do
    http
      .use(instrumentation: { instrumenter: ActiveSupport::Notifications.instrumenter })
      .via(ENV['PROXY_URL'], ENV['PROXY_PORT'])
      .timeout(read: 5, write: 5, connect: 1)
  end
end
```

At first I considered adding specific instrumentation options (which is our more immediate need), but I though providing access to the HTTP requests might be a bit more flexible, since it keeps the API surface small (only one extra setting) while giving users a lot of power to tweak the requests.

However, this **does** make the dependency on HTTP.rb part of the public API of the library, so if, in the future, Tarpon desires to move away from HTTP.rb, that would require a major version change as it would be a breaking change. WDYT?