### PR TITLE
Update grant_promotional to accept end_time_ms

### DIFF
--- a/lib/tarpon/request/subscriber/entitlement.rb
+++ b/lib/tarpon/request/subscriber/entitlement.rb
@@ -10,11 +10,12 @@ module Tarpon
           @entitlement_identifier = entitlement_identifier
         end
 
-        def grant_promotional(duration:, start_time_ms: nil)
+        def grant_promotional(duration: nil, start_time_ms: nil, end_time_ms: nil)
           body = {
             duration: duration,
-            start_time_ms: start_time_ms
-          }
+            start_time_ms: start_time_ms,
+            end_time_ms: end_time_ms
+          }.compact
 
           perform(method: :post, path: "#{path}/promotional", key: :secret, body: body)
         end

--- a/spec/tarpon/client/subscriber_spec.rb
+++ b/spec/tarpon/client/subscriber_spec.rb
@@ -59,12 +59,25 @@ RSpec.describe Tarpon::Client do
       let(:entitlement) { described_class.subscriber(app_user_id).entitlements(entitlement_id) }
 
       describe '.grant_promotional' do
-        it_behaves_like 'an http call to RevenueCat responding with subscriber object',
-                        method: :post, api_key: :secret do
-          let(:body) { { duration: 'weekly', start_time_ms: 123 } }
-          let(:client_call) { entitlement.grant_promotional(**body) }
-          let(:uri) do
-            "#{described_class.base_uri}/subscribers/#{app_user_id}/entitlements/#{entitlement_id}/promotional"
+        context 'with duration and start_time_ms' do
+          it_behaves_like 'an http call to RevenueCat responding with subscriber object',
+                          method: :post, api_key: :secret do
+            let(:body) { { duration: 'weekly', start_time_ms: 123 } }
+            let(:client_call) { entitlement.grant_promotional(**body) }
+            let(:uri) do
+              "#{described_class.base_uri}/subscribers/#{app_user_id}/entitlements/#{entitlement_id}/promotional"
+            end
+          end
+        end
+
+        context 'with end_time_ms' do
+          it_behaves_like 'an http call to RevenueCat responding with subscriber object',
+                          method: :post, api_key: :secret do
+            let(:body) { { end_time_ms: 123 } }
+            let(:client_call) { entitlement.grant_promotional(**body) }
+            let(:uri) do
+              "#{described_class.base_uri}/subscribers/#{app_user_id}/entitlements/#{entitlement_id}/promotional"
+            end
           end
         end
       end


### PR DESCRIPTION
RevenueCat has deprecated the use of the `duration` and `start_time_ms` params in favor of a new `end_time_ms` param. This change adds support for the new param without removing the deprecated ones.

[RevenueCat Docs](https://www.revenuecat.com/docs/api-v1#tag/entitlements/operation/grant-a-promotional-entitlement)

It should be noted that this change does mean that the `grant_promotional` method no longer *requires* any of the keyword arguments. One idea to mitigate this would be to raise if neither a `duration` nor a `end_time_ms` are provided. Let me know if you have thoughts and I can update accordingly.

Thank you for your hard work on this library. It's been really beneficial for us.